### PR TITLE
Modified Baidu PCS API URL

### DIFF
--- a/bddown_core.py
+++ b/bddown_core.py
@@ -102,7 +102,7 @@ class Pan(object):
         js = self._get_js(link, secret)
 
         # Fix #15
-        self.session.get('http://pcs.baidu.com/rest/2.0/pcs/file?method=plantcookie&type=ett')
+        self.session.get('http://d.pcs.baidu.com/rest/2.0/pcs/file?method=plantcookie&type=ett')
         self.pcsett = self.session.cookies.get('pcsett')
         logger.debug(self.pcsett, extra={'type': 'cookies', 'method': 'SetCookies'})
 


### PR DESCRIPTION
According to Baidu's wiki [here](http://developer.baidu.com/wiki/index.php?title=docs/pcs/rest/file_data_apis_list), `d.pcs.baidu.com` is supposed to be more stable than the original.

Personally, I encountered the problem that request to `pcs.baidu.com` throw an `requests.exceptions.ConnectionError` exception, basically caused by the unstable result of old API URL. This change fix the problem.