### PR TITLE
添加批量下载支持

### DIFF
--- a/bddown_core.py
+++ b/bddown_core.py
@@ -99,7 +99,12 @@ class Pan(object):
 
     def get_dlink(self, link, secret=None, fsid=None):
         info = FileInfo()
-        js = self._get_js(link, secret)
+        js = None
+        try:
+            js = self._get_js(link, secret)
+        except IndexError, e:
+            # Retry with new cookies
+            js = self._get_js(link, secret)
 
         # Fix #15
         self.session.get('http://d.pcs.baidu.com/rest/2.0/pcs/file?method=plantcookie&type=ett')


### PR DESCRIPTION
加批自动量下载支持，所有文件打包成zip下载，下载后文件带`-batch.zip`后缀，在以下情况下会自动批量下载：
- 多个文件或目录
- 一个或多个目录

单文件保持原来下载方式。

下面链接已测试：
- one dir, nested dir, multiple files: http://pan.baidu.com/s/1eQ2muhc fk56
- multiple dir, nested dir, multiple files: http://pan.baidu.com/s/1hqHHwhA pvqh
- multiple files: http://pan.baidu.com/s/1sjAD1lN ems7
- single file: http://pan.baidu.com/s/1bnlx7pd 4nmk